### PR TITLE
Fix Scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### v0.1.1
+* **[fix]** - Fixed an issue autoscrolling with some item selectors (#17)
+
 ### v0.1.0
 * **[improvement]** - Refactored to use glimmer components (#16)
 * **[breaking]** - The `focused` param is no longer two-way bound; you must use the `onFocusIn` and `onFocusOut` actions to observe and update the param passed in to `focused`. (#16)

--- a/addon/components/list-keyboard-navigator.js
+++ b/addon/components/list-keyboard-navigator.js
@@ -73,7 +73,9 @@ export default class ListKeyboardNavigatorComponent extends Component {
     if (_highlightedBy === 'mouse') return;
     if (highlightedIndex < 0) return;
 
-    let el = this.scrollElement.querySelector(`${itemSelector}:nth-of-type(${highlightedIndex + 1})`);
+    const el = this.scrollElement.querySelectorAll(itemSelector)[highlightedIndex];
+    if (!el) { return; }
+
     if (highlightedIndex === 0) {
       scrollToTop(el);
     } else if(highlightedIndex === this._list.length - 1) {
@@ -94,8 +96,8 @@ export default class ListKeyboardNavigatorComponent extends Component {
   scrollToSelectedItem() {
     if (this.selectedItemIndex < 0) { return; }
 
-    let el = this.scrollElement.querySelector(`${this.itemSelector}:nth-of-type(${this.selectedItemIndex + 1})`);
-    if(el) scrollIntoView(el);
+    const el = this.scrollElement.querySelectorAll(this.itemSelector)[this.selectedItemIndex];
+    if (el) { scrollIntoView(el); }
   }
 
   updateHighlightIndex({ index, highlightedBy }) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-list-keyboard-navigator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A component for handling keyboard navigation of a list of items",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### Summary
Native `querySelector` interprets `nth-of-type` differently than jQuery, meaning that often the element item wasn't found when highlighting, preventing automatically scrolling to it. Instead, we'll use `querySelectorAll` to get a node list, and then just access the desired node via subscript.