### PR TITLE
Bumped xmldom to 0.7.0 to address CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,9 @@
     "configPath": "tests/dummy/config"
   },
   "resolutions": {
+    "merge": "^2.1.1",
     "printf": "^0.6.1",
-    "xmlhttprequest-ssl": "^1.6.2",
-    "merge": "^2.1.1"
+    "xmldom": "github:xmldom/xmldom#0.7.0",
+    "xmlhttprequest-ssl": "^1.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12883,10 +12883,9 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
-xmldom@^0.1.19:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
-  integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
+xmldom@^0.1.19, "xmldom@github:xmldom/xmldom#0.7.0":
+  version "0.7.0"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 xmlhttprequest-ssl@^1.6.2, xmlhttprequest-ssl@~1.5.4:
   version "1.6.3"


### PR DESCRIPTION
### Summary
It would seem that the xmldom team is unable to publish this version to npm for some reason, so we'll use the code from GH. (cf. https://github.com/xmldom/xmldom/issues/271) We'll have to switch this back to using the version number once that issue is resolved.